### PR TITLE
Fix react-three fiber dependency conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "three": "^0.165.0",
-    "@react-three/fiber": "^9.0.36",
+    "@react-three/fiber": "^8.18.0",
     "@react-three/drei": "^9.97.3",
     "shadcn-ui": "^0.1.0"
   },


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore `node_modules` and `package-lock.json`
- pin `@react-three/fiber` to an 8.x release compatible with React 18

## Testing
- `npm install`
- `npm run build` *(fails: Rollup failed to resolve import `@/components/ui/button`)*

------
https://chatgpt.com/codex/tasks/task_e_6845ff2aa6188331a85c3f23580867aa