### PR TITLE
Fix XR vision loop cleanup

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,20 +74,21 @@ export default function App() {
     });
 
     let stopVision = false;
+    let visionInterval;
     (async () => {
       await loadOpenCV();
-      const interval = setInterval(() => {
+      visionInterval = setInterval(() => {
         if (stopVision || !videoRef.current) return;
         try {
           const frets = detectFrets(videoRef.current);
           drawFrets(frets);
         } catch {}
       }, 1500);
-      return () => clearInterval(interval);
     })();
 
     return () => {
       stopVision = true;
+      clearInterval(visionInterval);
       renderer.dispose();
     };
   }, [xrSupported]);


### PR DESCRIPTION
## Summary
- ensure the WebXR effect cleanup stops the vision loop

## Testing
- `npm run build` *(fails: Rollup failed to resolve import)*

------
https://chatgpt.com/codex/tasks/task_e_68460607487883318a0a4ddbde863159