### PR TITLE
Improve calibration UX with i18n

### DIFF
--- a/src/hooks/usePoseCalibration.js
+++ b/src/hooks/usePoseCalibration.js
@@ -1,16 +1,21 @@
 import { useState, useEffect, useCallback } from "react";
 import { loadOpenCV, detectFrets } from "../vision/fretDetection.js";
 import { calibratePose } from "../vision/calibratePose.js";
+import { useI18n } from "../i18n.js";
 export function usePoseCalibration(videoRef, scaleReal = 647) {
+  const { t } = useI18n();
   const [poseMatrix4, setPoseMatrix4] = useState(null);
   const [calibrated, setCalibrated] = useState(false);
   const [error, setError] = useState(null);
   const runCalibration = useCallback(async () => {
     if (!videoRef.current) return;
     try {
+      if (!videoRef.current.srcObject) {
+        throw new Error(t("errors.no_camera"));
+      }
       await loadOpenCV();
       const frets = detectFrets(videoRef.current);
-      if (frets.length < 4) throw new Error("No se detectaron suficientes trastes");
+      if (frets.length < 4) throw new Error(t("errors.no_frets"));
       const nut = { x: (frets[0].x1 + frets[0].x2)/2, y:(frets[0].y1+frets[0].y2)/2 };
       const br = frets[frets.length-1];
       const bridge = { x:(br.x1+br.x2)/2, y:(br.y1+br.y2)/2 };
@@ -19,10 +24,10 @@ export function usePoseCalibration(videoRef, scaleReal = 647) {
       const f12 = frets[Math.min(12, frets.length-1)];
       const fret12 = { x:(f12.x1+f12.x2)/2, y:(f12.y1+f12.y2)/2 };
       const { pose, success } = await calibratePose({nut,bridge,fret5,fret12}, scaleReal, videoRef.current.videoWidth, videoRef.current.videoHeight);
-      if(!success) throw new Error("solvePnP falló");
+      if(!success) throw new Error(t("errors.solvepnp"));
       setPoseMatrix4(pose.matrix4); setCalibrated(true); setError(null);
     } catch(e){ console.warn("Calibración fallida",e); setError(e.message); setCalibrated(false);}
-  }, [videoRef, scaleReal]);
+  }, [videoRef, scaleReal, t]);
   useEffect(() => {
     if (calibrated) return;
     const to = setTimeout(runCalibration, 2000);

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,50 @@
+import { createContext, useContext, useState, useCallback } from "react";
+
+const translations = {
+  es: {
+    browserUnsupported: "Tu navegador no soporta WebXR AR.",
+    calibrating: "Calibrando… mueve la cámara para enfocar todo el mástil",
+    retry: "Reintentar",
+    errorCalibrating: "Error calibrando:",
+    modes: { scales: "Escalas", chords: "Acordes", practice: "Practice" },
+    errors: {
+      no_camera: "Acceso a la cámara denegado.",
+      no_frets:
+        "No se detectaron suficientes trastes. Asegúrate de que todo el mástil esté visible y bien iluminado.",
+      solvepnp: "No se pudo calibrar la pose.",
+    },
+  },
+  en: {
+    browserUnsupported: "Your browser doesn't support WebXR AR.",
+    calibrating: "Calibrating… move the camera to capture the fretboard",
+    retry: "Retry",
+    errorCalibrating: "Calibration error:",
+    modes: { scales: "Scales", chords: "Chords", practice: "Practice" },
+    errors: {
+      no_camera: "Camera access denied. Please allow access.",
+      no_frets:
+        "Could not detect frets. Ensure the entire fretboard is visible and well-lit.",
+      solvepnp: "Pose calibration failed.",
+    },
+  },
+};
+
+const I18nContext = createContext({ t: (k) => k, lang: "es", setLang: () => {} });
+
+export function I18nProvider({ children }) {
+  const defaultLang = navigator.language.startsWith("es") ? "es" : "en";
+  const [lang, setLang] = useState(defaultLang);
+  const t = useCallback((key) => {
+    const keys = key.split(".");
+    let value = translations[lang];
+    for (const k of keys) value = value?.[k];
+    return value || key;
+  }, [lang]);
+  return (
+    <I18nContext.Provider value={{ t, lang, setLang }}>{children}</I18nContext.Provider>
+  );
+}
+
+export function useI18n() {
+  return useContext(I18nContext);
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./index.css";
+import { I18nProvider } from "./i18n.js";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <I18nProvider>
+      <App />
+    </I18nProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- add simple i18n context for Spanish/English text
- enhance calibration hook with clearer errors
- show spinner and messages during calibration
- localize UI strings and add language selector

## Testing
- `npm install` *(fails: ERESOLVE dependency conflict)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684609bef8bc8331835b5887e16979e0