### PR TITLE
Add chord and practice modes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Guitarra Tutor AR</title>
+  <title>Guitarra Tutor AR Demo</title>
   <script type="module" crossorigin src="/src/main.jsx"></script>
 </head>
 <body class="h-screen w-screen overflow-hidden bg-black">

--- a/frontend/src/overlays/chordOverlay.js
+++ b/frontend/src/overlays/chordOverlay.js
@@ -1,0 +1,48 @@
+import * as THREE from "three";
+
+/**
+ * Overlay that highlights chord tones across the fretboard. It mirrors the
+ * behavior of `createScaleOverlay` but uses a chord interval pattern instead.
+ */
+export function createChordOverlay({
+  scene,
+  tuning,
+  key,
+  chordPattern,
+  fretCount = 12,
+}) {
+  const group = new THREE.Group();
+  scene.add(group);
+  const noteMeshes = [];
+
+  const draw = (rootMidi) => {
+    noteMeshes.forEach((m) => group.remove(m));
+    noteMeshes.length = 0;
+
+    for (let s = 0; s < tuning.length; s++) {
+      const open = tuning[s];
+      for (let f = 0; f < fretCount; f++) {
+        const noteInChord = (open + f - rootMidi + 120) % 12;
+        const idx = chordPattern.indexOf(noteInChord);
+        if (idx !== -1) {
+          const mesh = new THREE.Mesh(
+            new THREE.SphereGeometry(0.006, 8, 8),
+            new THREE.MeshBasicMaterial({ color: idx === 0 ? 0xff0000 : 0x00ff00 })
+          );
+          mesh.position.set(-0.15 + s * 0.06, 0, -0.01 * f);
+          group.add(mesh);
+          noteMeshes.push(mesh);
+        }
+      }
+    }
+  };
+
+  draw(key);
+
+  return {
+    group,
+    updateKey(newKey) {
+      draw(newKey);
+    },
+  };
+}

--- a/frontend/src/overlays/practiceOverlay.js
+++ b/frontend/src/overlays/practiceOverlay.js
@@ -1,0 +1,36 @@
+import * as THREE from "three";
+
+/**
+ * Very small overlay used for practice mode. It shows a pulsing sphere that
+ * works like a visual metronome.
+ */
+export function createPracticeOverlay({ scene, bpm = 60 }) {
+  const group = new THREE.Group();
+  scene.add(group);
+
+  const sphere = new THREE.Mesh(
+    new THREE.SphereGeometry(0.01, 16, 16),
+    new THREE.MeshBasicMaterial({ color: 0x00ffff })
+  );
+  sphere.position.set(0, 0.025, 0);
+  group.add(sphere);
+
+  const tick = () => {
+    sphere.scale.setScalar(1.5);
+    setTimeout(() => sphere.scale.setScalar(1), 100);
+  };
+  tick();
+  const interval = 60000 / bpm;
+  let id = setInterval(tick, interval);
+
+  return {
+    group,
+    updateBpm(newBpm) {
+      clearInterval(id);
+      id = setInterval(tick, 60000 / newBpm);
+    },
+    dispose() {
+      clearInterval(id);
+    },
+  };
+}

--- a/frontend/src/overlays/scaleOverlay.js
+++ b/frontend/src/overlays/scaleOverlay.js
@@ -1,0 +1,50 @@
+import * as THREE from "three";
+
+/**
+ * Creates a basic overlay that highlights scale notes on top of the virtual
+ * fretboard. This implementation is intentionally very small and does not aim
+ * to be musically perfect; it just renders small spheres at the frets that
+ * belong to the selected scale.
+ */
+export function createScaleOverlay({
+  scene,
+  tuning,
+  key,
+  scalePattern,
+  fretCount = 12,
+}) {
+  const group = new THREE.Group();
+  scene.add(group);
+  const noteMeshes = [];
+
+  const draw = (rootMidi) => {
+    // clear previous meshes
+    noteMeshes.forEach((m) => group.remove(m));
+    noteMeshes.length = 0;
+
+    for (let s = 0; s < tuning.length; s++) {
+      const open = tuning[s];
+      for (let f = 0; f < fretCount; f++) {
+        const noteInScale = (open + f - rootMidi + 120) % 12;
+        if (scalePattern.includes(noteInScale)) {
+          const mesh = new THREE.Mesh(
+            new THREE.SphereGeometry(0.006, 8, 8),
+            new THREE.MeshBasicMaterial({ color: 0xff0000 })
+          );
+          mesh.position.set(-0.15 + s * 0.06, 0, -0.01 * f);
+          group.add(mesh);
+          noteMeshes.push(mesh);
+        }
+      }
+    }
+  };
+
+  draw(key);
+
+  return {
+    group,
+    updateKey(newKey) {
+      draw(newKey);
+    },
+  };
+}

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Guitarra Tutor AR</title>
+    <title>Guitarra Tutor AR Demo</title>
     <script type="module" crossorigin src="/src/main.jsx"></script>
   </head>
   <body class="h-screen w-screen overflow-hidden bg-black">

--- a/src/overlays/chordOverlay.js
+++ b/src/overlays/chordOverlay.js
@@ -1,0 +1,48 @@
+import * as THREE from "three";
+
+/**
+ * Overlay that highlights chord tones across the fretboard. It mirrors the
+ * behavior of `createScaleOverlay` but uses a chord interval pattern instead.
+ */
+export function createChordOverlay({
+  scene,
+  tuning,
+  key,
+  chordPattern,
+  fretCount = 12,
+}) {
+  const group = new THREE.Group();
+  scene.add(group);
+  const noteMeshes = [];
+
+  const draw = (rootMidi) => {
+    noteMeshes.forEach((m) => group.remove(m));
+    noteMeshes.length = 0;
+
+    for (let s = 0; s < tuning.length; s++) {
+      const open = tuning[s];
+      for (let f = 0; f < fretCount; f++) {
+        const noteInChord = (open + f - rootMidi + 120) % 12;
+        const idx = chordPattern.indexOf(noteInChord);
+        if (idx !== -1) {
+          const mesh = new THREE.Mesh(
+            new THREE.SphereGeometry(0.006, 8, 8),
+            new THREE.MeshBasicMaterial({ color: idx === 0 ? 0xff0000 : 0x00ff00 })
+          );
+          mesh.position.set(-0.15 + s * 0.06, 0, -0.01 * f);
+          group.add(mesh);
+          noteMeshes.push(mesh);
+        }
+      }
+    }
+  };
+
+  draw(key);
+
+  return {
+    group,
+    updateKey(newKey) {
+      draw(newKey);
+    },
+  };
+}

--- a/src/overlays/practiceOverlay.js
+++ b/src/overlays/practiceOverlay.js
@@ -1,0 +1,36 @@
+import * as THREE from "three";
+
+/**
+ * Very small overlay used for practice mode. It shows a pulsing sphere that
+ * works like a visual metronome.
+ */
+export function createPracticeOverlay({ scene, bpm = 60 }) {
+  const group = new THREE.Group();
+  scene.add(group);
+
+  const sphere = new THREE.Mesh(
+    new THREE.SphereGeometry(0.01, 16, 16),
+    new THREE.MeshBasicMaterial({ color: 0x00ffff })
+  );
+  sphere.position.set(0, 0.025, 0);
+  group.add(sphere);
+
+  const tick = () => {
+    sphere.scale.setScalar(1.5);
+    setTimeout(() => sphere.scale.setScalar(1), 100);
+  };
+  tick();
+  const interval = 60000 / bpm;
+  let id = setInterval(tick, interval);
+
+  return {
+    group,
+    updateBpm(newBpm) {
+      clearInterval(id);
+      id = setInterval(tick, 60000 / newBpm);
+    },
+    dispose() {
+      clearInterval(id);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add chord and practice overlay modules
- support chord and practice modes in `App.jsx`
- expose controls for chords and practice BPM
- replicate changes in `frontend` folder
- bump HTML title text to "Guitarra Tutor AR Demo"

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684609ca08748331a6fa628e9266df79